### PR TITLE
Fix sitemap url wrapping

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -116,7 +116,8 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
-  <loc>https://ezequiel-orazi.online/blog/el-nuevo-paradigma-de-las-apps</loc>
+  <url>
+    <loc>https://ezequiel-orazi.online/blog/el-nuevo-paradigma-de-las-apps</loc>
     <lastmod>2025-04-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## Summary
- fix missing `<url>` wrapper in sitemap entry for *el-nuevo-paradigma-de-las-apps*

## Testing
- `vitest` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871dc74c76c83338a5e99173d9dacef