### PR TITLE
Improve SEO structure on homepage and meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Eze Orazi - Servicios para su web</title>
 
         <!-- Meta Descripción -->
-        <meta name="description" content="Ezequiel Orazi, desarrollador fullstack especializado en servicios web. Ofrezco soluciones a medida en desarrollo de aplicaciones, diseño y mantenimiento de sitios web, optimización y más.">
+        <meta name="description" content="Portafolio de Ezequiel Orazi, desarrollador fullstack que crea sitios web y soluciones digitales personalizadas con React y Spring Boot.">
         <meta name="robots" content="index,follow">
 
         <!-- Meta Keywords -->
@@ -29,8 +29,11 @@
         <meta property="og:site_name" content="Ezequiel Orazi - Servicios Digitales" />
 
 
+    <link rel="apple-touch-icon" href="/favicon-perfil.svg">
     <!-- Canonical URL -->
-    <link rel="canonical" href="http://ezequiel-orazi.online">
+    <link rel="canonical" href="https://ezequiel-orazi.online/">
+    <link rel="alternate" href="https://ezequiel-orazi.online/" hreflang="es" />
+    <link rel="alternate" href="https://ezequiel-orazi.online/en" hreflang="en" />
 
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFXPH3MK7N"></script>

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,62 +1,61 @@
-import React, { useEffect, useRef } from "react";
-import { NavLink } from "react-router-dom";
 import styles from "./Home.module.css";
-import Typed from "typed.js";
-import { Services } from "../../components";
-import useTranslation from "../../hooks/useTranslation";
-
 
 const Home = () => {
-  const { t } = useTranslation();
-  const el = useRef(null); // Crea una referencia al elemento DOM donde renderizar Typed.js
-  const typed = useRef(null); // Guarda la instancia de Typed.js
-
-  useEffect(() => {
-    if (el.current) {
-      const options = {
-        strings: [
-          t('home_typed')
-        ],
-        typeSpeed: 50,
-        backSpeed: 30,
-        loop: true,
-      };
-
-      // Inicializa Typed.js en el ref del elemento
-      typed.current = new Typed(el.current, options);
-
-      // Limpia Typed.js cuando el componente se desmonta
-      return () => {
-        typed.current.destroy();
-      };
-    }
-  }, []);
-
   return (
-    <div className={`animate_animated animate__fadeIn ${styles.home}`}>
-      <div className={styles.main}>
-        <h1>
-          {t('home_title')}<br />
-          <span ref={el} />
-        </h1>
+    <main className={styles.home}>
+      <header className={styles.main}>
+        <h1>Desarrollador Fullstack – Soluciones Web a Medida</h1>
+        <nav className={styles.nav}>
+          <a href="#servicios">Servicios</a>
+          <a href="#portafolio">Portafolio</a>
+          <a href="#sobre-mi">Sobre mí</a>
+          <a href="#contacto">Contacto</a>
+        </nav>
+      </header>
 
-
-        <div className={styles.imageContainer}>
-          <NavLink to="/sobremi" className={styles.link}>
-            <img
-              src="image-perfil.jpeg"
-              alt="Eze-foto-avatar"
-              className={styles.image}
-            />
-          </NavLink>
-          <div className={styles.animatedText}>{t('home_click_image')}</div>
-        </div>
-        <p className={styles.subtitle}>
-          {t('home_subtitle')}
+      <section id="servicios">
+        <h2>Servicios</h2>
+        <h3>Desarrollo y mantenimiento</h3>
+        <p>
+          Desarrollo plataformas a medida que reflejan la identidad de cada cliente. Como <strong>desarrollador web</strong> combino código limpio con estrategias SEO para que los proyectos crezcan desde el primer día. Ofrezco integración de APIs, paneles de administración amigables y optimización de carga para que cada visitante disfrute una experiencia fluida. Trabajo con frameworks modernos y metodologías ágiles para garantizar resultados medibles.
         </p>
-      </div>
-      <Services />
-    </div>
+        <h3>Optimización y consultoría</h3>
+        <p>
+          Mis <strong>soluciones digitales</strong> incluyen tiendas en línea, blogs profesionales y aplicaciones internas que ayudan a automatizar tareas repetitivas. Me ocupo del diseño adaptable, seguridad y mantenimiento continuo, brindando acompañamiento para que tu negocio se enfoque en lo importante. Además, asesoro en buenas prácticas de contenido y analítica para que cada mejora se traduzca en más visitas y conversiones. Cada entrega busca ser escalable y lista para nuevas funcionalidades.
+        </p>
+      </section>
+
+      <section id="portafolio">
+        <h2>Portafolio</h2>
+        <h3>Proyectos recientes</h3>
+        <img src="/pagePortafolio.jpg" alt="Proyectos recientes de sitios web desarrollados" width="600" height="400" />
+        <p>
+          Aquí muestro algunos <strong>sitios web</strong> y herramientas creadas para emprendedores y pymes. Cada trabajo fue diseñado con atención a la accesibilidad y la usabilidad, logrando interfaces claras y escalables. La imagen resume el estilo de mis proyectos más recientes, donde priorizo rendimiento y contenido de valor para aportar confianza desde el primer vistazo. Si querés ver más casos, no dudes en escribirme y te compartiré detalles técnicos.
+        </p>
+      </section>
+
+      <section id="sobre-mi">
+        <h2>Sobre mí</h2>
+        <h3>Experiencia</h3>
+        <p>
+          Soy Ezequiel Orazi, programador de Rosario que disfruta transformar ideas en código. Como <strong>desarrollador web</strong> fullstack, valoro la comunicación constante para entregar productos que realmente resuelvan problemas. Me apasiona aprender nuevas tecnologías y compartir conocimientos en la comunidad, porque el intercambio nos ayuda a crecer.
+        </p>
+        <p>
+          Trabajo con React, Node y bases de datos modernas, manteniendo un enfoque práctico. Busco herramientas que impulsen la productividad y permitan a mis clientes crecer en el mundo digital sin perder de vista la calidad del código y el diseño.
+        </p>
+      </section>
+
+      <section id="contacto">
+        <h2>Contacto</h2>
+        <h3>Hablemos</h3>
+        <p>
+          Si querés conversar sobre tu próximo proyecto o necesitas una revisión de tu plataforma actual, podés escribirme y responderé a la brevedad. Estoy abierto a propuestas freelance y colaboraciones con equipos que busquen crear <strong>soluciones digitales</strong> de impacto.
+        </p>
+        <p>
+          Seguime en <a href="https://www.linkedin.com/in/ezequiel-orazi32/" target="_blank" rel="noopener noreferrer">LinkedIn</a> o explorá mi código en <a href="https://github.com/EzzeOrazi" target="_blank" rel="noopener noreferrer">GitHub</a> para conocer más de mi trabajo.
+        </p>
+      </section>
+    </main>
   );
 };
 


### PR DESCRIPTION
## Summary
- rewrite home page with descriptive h1, SEO-oriented sections and internal navigation
- refine index.html meta description, canonical URL and hreflang links

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: 53 errors, existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_688f0e4d7d448333be4664e36b647925