### PR TITLE
Refine home layout and navbar styling

### DIFF
--- a/src/layouts/Navbar/Navbar.jsx
+++ b/src/layouts/Navbar/Navbar.jsx
@@ -63,7 +63,7 @@ function Navbar() {
 export default Navbar;
 
 const NavContainer = styled.nav`
-  padding: .4rem;
+  padding: 0.5rem 1rem;
   background-color: var(--color-dark);
   display: flex;
   align-items: center;
@@ -75,7 +75,7 @@ const NavContainer = styled.nav`
   }
 
   .logo a {
-    color: var(--color-yellow);
+    color: var(--color-light);
     font-weight: bold;
     text-decoration: none;
     font-size: 1.5rem;
@@ -92,7 +92,7 @@ const NavContainer = styled.nav`
     transition: all .5s ease;
     z-index: 1000; /* Asegúrate de que los enlaces estén por encima del contenido */
     a {
-      color: var(--color-yellow);
+      color: var(--color-light);
       font-size: 2rem;
       display: block;
       text-decoration: none;
@@ -103,7 +103,7 @@ const NavContainer = styled.nav`
       margin: 0;
       a {
         font-size: 1rem;
-        color: var(--color-yellow);
+        color: var(--color-light);
         display: inline;
         margin-right: 1rem;
       }
@@ -125,7 +125,7 @@ const NavContainer = styled.nav`
     a {
       font-size: 2rem;
       margin-top: 1rem;
-      color: var(--color-yellow);
+      color: var(--color-light);
     }
   }
 

--- a/src/layouts/Navbar/Navbar.module.css
+++ b/src/layouts/Navbar/Navbar.module.css
@@ -1,5 +1,5 @@
 .logo a {
-  color: var(--color-yellow);
+  color: var(--color-light);
   text-decoration: none;
   font-size: 2rem;
   font-weight: 700;
@@ -22,8 +22,8 @@
 
 .toggle {
   background: none;
-  border: 1px solid var(--color-yellow);
-  color: var(--color-yellow);
+  border: 1px solid var(--color-light);
+  color: var(--color-light);
   padding: 0.2rem 0.5rem;
   cursor: pointer;
   border-radius: 4px;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -5,12 +5,13 @@ const Home = () => {
     <main className={styles.home}>
       <header className={styles.main}>
         <h1>Desarrollador Fullstack – Soluciones Web a Medida</h1>
-        <nav className={styles.nav}>
-          <a href="#servicios">Servicios</a>
-          <a href="#portafolio">Portafolio</a>
-          <a href="#sobre-mi">Sobre mí</a>
-          <a href="#contacto">Contacto</a>
-        </nav>
+        <div className={styles.imageContainer}>
+          <img
+            src="/image-perfil.jpeg"
+            alt="Retrato de Ezequiel Orazi"
+            className={styles.image}
+          />
+        </div>
       </header>
 
       <section id="servicios">

--- a/src/pages/Home/Home.module.css
+++ b/src/pages/Home/Home.module.css
@@ -1,23 +1,30 @@
 .home {
-  padding: 0;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.home section {
+  margin: 2rem auto;
+  padding: 1rem;
 }
 
 .main {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  padding-bottom: 50px;
-  padding-top: 80px;
+  gap: 2rem;
+  padding: 80px 0 50px;
+  text-align: center;
+  margin: 0 auto;
 }
 
 .main h1 {
-  flex: 1 1 70%;
+  flex: 1 1 300px;
   margin: 0;
   color: var(--color-dark);
   font-size: 2rem; /* Tamaño más pequeño en móviles */
   min-height: 160px; /* Ajusta el tamaño mínimo para evitar desplazamientos */
-  padding-left: 1rem;
 }
 
 .subtitle {
@@ -94,8 +101,7 @@
 @media (min-width: 768px) {
   .main {
     flex-direction: row;
-    justify-content: start;
-    text-align: left;
+    justify-content: center;
   }
 
   .main h1 {
@@ -105,7 +111,7 @@
 
   img {
     width: 50%;
-    
+
   }
 
   .subtitle {


### PR DESCRIPTION
## Summary
- remove redundant navigation from Home page and showcase avatar
- center layout sections with improved spacing
- improve navbar contrast and padding for clarity

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f124d7da883338ab90db3362a7e4a